### PR TITLE
Allow empty strings for name

### DIFF
--- a/lib/SendGrid/Email.php
+++ b/lib/SendGrid/Email.php
@@ -73,7 +73,7 @@ class Email
             foreach ($name as $n) {
                 $this->addToName($n);
             }
-        } elseif ($name) {
+        } elseif (is_string($name)) {
             $this->addToName($name);
         }
 
@@ -189,7 +189,7 @@ class Email
             foreach ($name as $n) {
                 $this->addCcName($n);
             }
-        } elseif ($name) {
+        } elseif (is_string($name)) {
             $this->addCcName($name);
         }
 
@@ -256,7 +256,7 @@ class Email
             foreach ($name as $n) {
                 $this->addBccName($n);
             }
-        } elseif ($name) {
+        } elseif (is_string($name)) {
             $this->addBccName($name);
         }
 


### PR DESCRIPTION
When adding multiple name/email combo's to a recipient list we occasionally have contacts with no name. An empty string validates to false, causing these empty string names to be omitted, leading to a mismatch of the name and email array sizes. 
